### PR TITLE
shorten toast removal delay

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+export const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- reduce toast removal delay to 5 seconds via exported constant

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-empty-object, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68502d4e60b48322baa688d008197707