### PR TITLE
Enable strict TypeScript

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,7 +15,8 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": false,
+    "strict": true,
+    "strictNullChecks": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitAny": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,12 @@
     "paths": {
       "@/*": ["./src/*"]
     },
+    "strict": true,
+    "strictNullChecks": true,
     "noImplicitAny": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,
     "allowJs": true,
-    "noUnusedLocals": false,
-    "strictNullChecks": false
+    "noUnusedLocals": false
   }
 }


### PR DESCRIPTION
## Summary
- enable strict mode for TypeScript
- keep tests green

## Testing
- `npm test`
- `npx tsc -p tsconfig.app.json`


------
https://chatgpt.com/codex/tasks/task_e_68502d48f7648322975bafbcbfbe5fce