### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run linter
+        run: npm run lint
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add a workflow to run npm lint and tests on PRs and pushes to main

## Testing
- `npm ci` *(fails: blocked by network)*
- `npm run lint` *(fails: missing dependencies because ci failed)*

------
https://chatgpt.com/codex/tasks/task_e_68502d4781608322a54131d8d6a334d5